### PR TITLE
Add check to only read payment dates when they exist

### DIFF
--- a/controllers/dashboard.js
+++ b/controllers/dashboard.js
@@ -60,9 +60,17 @@ module.exports = {
 
           if(divResponse.data.historical) {
             const currentDivInfo = divResponse.data.historical[0];
-            const pastDivInfo = divResponse.data.historical[1];
-            let firstMonth = currentDivInfo.paymentDate.slice(5, 7);
-            let secondMonth = pastDivInfo.paymentDate.slice(5, 7);
+            let pastDivInfo;
+            let firstMonth;
+            let secondMonth;
+            if(divResponse.data.historical.length > 1) {
+              // DATE DATE DATE
+              pastDivInfo = divResponse.data.historical[1];
+              firstMonth = currentDivInfo.paymentDate.slice(5, 7);
+              secondMonth = pastDivInfo.paymentDate.slice(5, 7);
+            } else {
+              pastDivInfo = {};
+            }
             
             if(Number(firstMonth) < 10) { 
               // Gets rid of zero at the front

--- a/controllers/stock.js
+++ b/controllers/stock.js
@@ -66,7 +66,10 @@ module.exports = {
             firstMonth = Number(firstMonth);
           }
     
-          let secondMonth = dividendInfo.data.historical[1].paymentDate.slice(5, 7);
+          let secondMonth;
+          if(dividendInfo.data.historical.length > 1) {
+            secondMonth = dividendInfo.data.historical[1].paymentDate.slice(5, 7);
+          }
           
           if(Number(secondMonth) < 10) {
             secondMonth = Number(secondMonth.slice(1));


### PR DESCRIPTION
I realized the issue with this was when we tried to access a stocks previous dividend data when it didn't exist. I added a check for this that fixes the issue for now.